### PR TITLE
Fix for late enabled WorldGuard

### DIFF
--- a/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
+++ b/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
@@ -30,7 +30,7 @@ public class ExtraContextsPlugin extends JavaPlugin {
 
     private void register(String option, String requiredPlugin, Supplier<ContextCalculator<Player>> calculatorSupplier) {
         if (getConfig().getBoolean(option, false)) {
-            if (requiredPlugin != null && !getServer().getPluginManager().isPluginEnabled(requiredPlugin)) {
+            if (requiredPlugin != null && getServer().getPluginManager().getPlugin(requiredPlugin) == null) {
                 getLogger().info(requiredPlugin + " not present. Skipping registration of '" + option + "'...");
             } else {
                 getLogger().info("Registering '" + option + "' calculator.");


### PR DESCRIPTION
On our server will WorldGuard be too late enabled for ExtraContexts. The Plugin checks now only if the Plugin is present and not if it enabled. Maybe this ist helpfull for some other servers.