### PR TITLE
Add permission context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
-            <version>5.0</version>
+            <version>5.1</version>
             <scope>provided</scope>
         </dependency>
         <!-- Bukkit -->

--- a/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
+++ b/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
@@ -3,6 +3,7 @@ package me.lucko.extracontexts;
 import me.lucko.extracontexts.calculators.DimensionCalculator;
 import me.lucko.extracontexts.calculators.GamemodeCalculator;
 import me.lucko.extracontexts.calculators.HasPlayedBeforeCalculator;
+import me.lucko.extracontexts.calculators.PermissionCalculator;
 import me.lucko.extracontexts.calculators.PlaceholderApiCalculator;
 import me.lucko.extracontexts.calculators.TeamCalculator;
 import me.lucko.extracontexts.calculators.WhitelistedCalculator;
@@ -26,6 +27,7 @@ import java.util.function.Supplier;
 
 public class ExtraContextsPlugin extends JavaPlugin implements CommandExecutor {
     private ContextManager contextManager;
+    private LuckPerms luckPerms;
     private final List<ContextCalculator<Player>> registeredCalculators = new ArrayList<>();
 
     @Override
@@ -35,6 +37,7 @@ public class ExtraContextsPlugin extends JavaPlugin implements CommandExecutor {
             throw new IllegalStateException("LuckPerms API not loaded.");
         }
         this.contextManager = luckPerms.getContextManager();
+        this.luckPerms = luckPerms;
 
         saveDefaultConfig();
         setup();
@@ -63,6 +66,7 @@ public class ExtraContextsPlugin extends JavaPlugin implements CommandExecutor {
         register("team", null, TeamCalculator::new);
         register("has-played-before", null, HasPlayedBeforeCalculator::new);
         register("placeholderapi", "PlaceholderAPI", () -> new PlaceholderApiCalculator(getConfig().getConfigurationSection("placeholderapi-placeholders")));
+        register("permission", "LuckPerms", () -> new PermissionCalculator(this.luckPerms));
     }
 
     private void register(String option, String requiredPlugin, Supplier<ContextCalculator<Player>> calculatorSupplier) {

--- a/src/main/java/me/lucko/extracontexts/calculators/PermissionCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/PermissionCalculator.java
@@ -24,7 +24,7 @@ public class PermissionCalculator implements ContextCalculator<Player> {
 
         CachedPermissionData permissionData = user.getCachedData().getPermissionData(contextManager.getStaticQueryOptions());
         permissionData.getPermissionMap().forEach((node, value) -> {
-            if (value && permissionData.checkPermission(node).asBoolean()) consumer.accept(KEY, node);
+            if (permissionData.checkPermission(node).asBoolean()) consumer.accept(KEY, node);
         });
     }
 

--- a/src/main/java/me/lucko/extracontexts/calculators/PermissionCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/PermissionCalculator.java
@@ -1,0 +1,31 @@
+package me.lucko.extracontexts.calculators;
+
+import net.luckperms.api.LuckPerms;
+import net.luckperms.api.cacheddata.CachedPermissionData;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextManager;
+import net.luckperms.api.model.user.User;
+import org.bukkit.entity.Player;
+
+public class PermissionCalculator implements ContextCalculator<Player> {
+    private static final String KEY = "permission";
+
+    private final LuckPerms api;
+
+    public PermissionCalculator(LuckPerms api) {
+        this.api = api;
+    }
+
+    @Override
+    public void calculate(Player target, ContextConsumer consumer) {
+        User user = api.getPlayerAdapter(Player.class).getUser(target);
+        ContextManager contextManager = api.getContextManager();
+
+        CachedPermissionData permissionData = user.getCachedData().getPermissionData(contextManager.getStaticQueryOptions());
+        permissionData.getPermissionMap().forEach((node, value) -> {
+            if (value && permissionData.checkPermission(node).asBoolean()) consumer.accept(KEY, node);
+        });
+    }
+
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,3 +52,9 @@ has-played-before: false
 placeholderapi: false
 placeholderapi-placeholders:
   allowflight: "%player_allow_flight%"
+
+# Provides the 'permission' context
+# Returns if the player has the specified permission
+#
+# e.g. permission=luckperms.*
+permission: false


### PR DESCRIPTION
Adds a `permission=` context.

This only works for nodes the user has explicitly set and eg. not wildcard ones.