### PR TITLE
Towny contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,55 @@ placeholderapi-placeholders:
 > allowflight=true
 
 ___
+#### TownyAdvanced
+#### `towny:in-town`
+Returns true if player's location within a Town
+
+e.g.
+
+> towny:in-town=false
+
+#### `towny:town`
+Returns name of the town (if any) at a player's current location
+
+e.g.
+
+> towny:town=
+>
+> towny:town=Atlantis
+
+**config:**
+```yaml
+towny-town: true
+```
+
+#### `towny:in-nation`
+Returns true if player's location within a Nation
+
+e.g.
+
+> towny:in-nation=true
+
+#### `towny:town`
+Returns name of the nation (if any) at a player's current location
+
+e.g.
+
+> towny:nation=Rome
+
+**config:**
+```yaml
+towny-nation: true
+```
+
+#### `towny:in-wilds`
+Returns true if player's location in the wilderness
+
+e.g.
+
+> towny:in-wilds=false
+
+**config:**
+```yaml
+towny-wilds: true
+```

--- a/pom.xml
+++ b/pom.xml
@@ -108,12 +108,22 @@
             <version>2.9.2</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.TownyAdvanced</groupId>
+            <artifactId>Towny</artifactId>
+            <version>0.96.2.0</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <repositories>
         <repository>
             <id>luck-repo</id>
             <url>https://repo.lucko.me/</url>
+        </repository>
+        <repository>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
     </repositories>
 

--- a/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
+++ b/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
@@ -5,6 +5,9 @@ import me.lucko.extracontexts.calculators.GamemodeCalculator;
 import me.lucko.extracontexts.calculators.HasPlayedBeforeCalculator;
 import me.lucko.extracontexts.calculators.PlaceholderApiCalculator;
 import me.lucko.extracontexts.calculators.TeamCalculator;
+import me.lucko.extracontexts.calculators.TownyNationCalculator;
+import me.lucko.extracontexts.calculators.TownyTownCalculator;
+import me.lucko.extracontexts.calculators.TownyWildsCalculator;
 import me.lucko.extracontexts.calculators.WhitelistedCalculator;
 import me.lucko.extracontexts.calculators.WorldGuardFlagCalculator;
 import me.lucko.extracontexts.calculators.WorldGuardRegionCalculator;
@@ -55,6 +58,9 @@ public class ExtraContextsPlugin extends JavaPlugin implements CommandExecutor {
     }
 
     private void setup() {
+        register("towny-town", "Towny", TownyTownCalculator::new);
+        register("towny-nation", "Towny", TownyNationCalculator::new);
+        register("towny-wilds", "Towny", TownyWildsCalculator::new);
         register("worldguard-region", "WorldGuard", WorldGuardRegionCalculator::new);
         register("worldguard-flag", "WorldGuard", WorldGuardFlagCalculator::new);
         register("gamemode", null, GamemodeCalculator::new);

--- a/src/main/java/me/lucko/extracontexts/calculators/TownyNationCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/TownyNationCalculator.java
@@ -1,0 +1,57 @@
+package me.lucko.extracontexts.calculators;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.Town;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+
+public class TownyNationCalculator implements ContextCalculator<Player> {
+    private static final String IN_NATION_KEY = "towny:in-nation";
+    private static final String NATION_KEY = "towny:nation";
+
+    private final TownyAPI towny = TownyAPI.getInstance();
+
+    @Override
+    public void calculate(Player player, ContextConsumer contextConsumer) {
+        final TownBlock townBlock = towny.getTownBlock(player.getLocation());
+        if (townBlock == null) {
+            contextConsumer.accept(IN_NATION_KEY, "false");
+        } else {
+            if (townBlock.hasTown()) {
+                try {
+                    final Town town = townBlock.getTown();
+                    if (town.hasNation()) {
+                        contextConsumer.accept(IN_NATION_KEY, "true");
+                        try {
+                            contextConsumer.accept(NATION_KEY, town.getNation().getName());
+                        } catch (NotRegisteredException e) {
+                            e.printStackTrace();
+                        }
+                    } else {
+                        contextConsumer.accept(IN_NATION_KEY, "false");
+                    }
+                } catch (NotRegisteredException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                contextConsumer.accept(IN_NATION_KEY, "false");
+            }
+        }
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        final ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+        for (String nationKey : towny.getDataSource().getNationsKeys()) {
+            builder.add(NATION_KEY, nationKey);
+        }
+        builder.add(IN_NATION_KEY, "true");
+        builder.add(IN_NATION_KEY, "false");
+        return builder.build();
+    }
+}

--- a/src/main/java/me/lucko/extracontexts/calculators/TownyTownCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/TownyTownCalculator.java
@@ -1,0 +1,47 @@
+package me.lucko.extracontexts.calculators;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
+import com.palmergames.bukkit.towny.object.TownBlock;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+
+public class TownyTownCalculator implements ContextCalculator<Player> {
+    private static final String IN_TOWN_KEY = "towny:in-town";
+    private static final String TOWN_KEY = "towny:town";
+
+    private final TownyAPI towny = TownyAPI.getInstance();
+
+    @Override
+    public void calculate(Player player, ContextConsumer contextConsumer) {
+        final TownBlock townBlock = towny.getTownBlock(player.getLocation());
+        if (townBlock == null) {
+            contextConsumer.accept(IN_TOWN_KEY, "false");
+        } else {
+            if (townBlock.hasTown()) {
+                contextConsumer.accept(IN_TOWN_KEY, "true");
+                try {
+                    contextConsumer.accept(TOWN_KEY, townBlock.getTown().getName());
+                } catch (NotRegisteredException e) {
+                    e.printStackTrace();
+                }
+            } else {
+                contextConsumer.accept(IN_TOWN_KEY, "false");
+            }
+        }
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        final ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+        for (String townKey : towny.getDataSource().getTownsKeys()) {
+            builder.add(TOWN_KEY, townKey);
+        }
+        builder.add(IN_TOWN_KEY, "true");
+        builder.add(IN_TOWN_KEY, "false");
+        return builder.build();
+    }
+}

--- a/src/main/java/me/lucko/extracontexts/calculators/TownyWildsCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/TownyWildsCalculator.java
@@ -1,0 +1,27 @@
+package me.lucko.extracontexts.calculators;
+
+import com.palmergames.bukkit.towny.TownyAPI;
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+import org.bukkit.entity.Player;
+
+public class TownyWildsCalculator implements ContextCalculator<Player> {
+    private static final String IN_WILDS_KEY = "towny:in-wilds";
+
+    private final TownyAPI towny = TownyAPI.getInstance();
+
+    @Override
+    public void calculate(Player player, ContextConsumer contextConsumer) {
+        contextConsumer.accept(IN_WILDS_KEY, towny.isWilderness(player.getLocation()) ? "true" : "false");
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        final ImmutableContextSet.Builder builder = ImmutableContextSet.builder();
+        builder.add(IN_WILDS_KEY, "true");
+        builder.add(IN_WILDS_KEY, "false");
+        return builder.build();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,3 +52,20 @@ has-played-before: false
 placeholderapi: false
 placeholderapi-placeholders:
   allowflight: "%player_allow_flight%"
+
+### Addition: Towny Contexts
+# Provides the 'towny:town' and 'towny:in-town' contexts.
+# Returns the name of the Town the player is currently in.
+#
+# e.g. towny:in-town=true and towny:town=townName
+towny-town: false
+# Provides the 'towny:town' and 'towny:in-nation' contexts.
+# Returns the name of the Nation the player is currently in.
+#
+# e.g. towny:in-nation=true and towny:nation=nationName
+towny-nation: false
+# Provides the 'towny:in-wilds' context.
+# Returns if the player is currently in the wilderness.
+#
+# e.g. towny:in-wilds=true
+towny-wilds: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: ${project.version}
 author: Luck
 main: me.lucko.extracontexts.ExtraContextsPlugin
 depend: [LuckPerms]
-softdepend: [WorldGuard, PlaceholderAPI]
+softdepend: [WorldGuard, PlaceholderAPI, Towny]
 api-version: 1.13
 
 commands:


### PR DESCRIPTION
As suggested in LuckPerms' documentation, I used the same methods found in this plugin to create my own contexts and noticed afterward that issue #10 had raised similar interest in the creation of Towny-aware contexts. I contribute the contexts, calculators, config nodes and documentation all. I recognize that placing a dependency on Towny's API may not be desired for this project, so if I am not able to merge directly, could we work out something else to make this code available?