### PR TITLE
Add 'is-op' context calculator

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ e.g.
 > whitelisted=true
 
 ___
+#### `is-op`
+Returns if the player is a server operator or not
+
+e.g.
+
+> is-op=true
+
+___
 #### `team`
 Returns the name of the team the players is in
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
+++ b/src/main/java/me/lucko/extracontexts/ExtraContextsPlugin.java
@@ -1,6 +1,7 @@
 package me.lucko.extracontexts;
 
 import me.lucko.extracontexts.calculators.HasPlayedBeforeCalculator;
+import me.lucko.extracontexts.calculators.OpCalculator;
 import me.lucko.extracontexts.calculators.PlaceholderApiCalculator;
 import me.lucko.extracontexts.calculators.TeamCalculator;
 import me.lucko.extracontexts.calculators.WhitelistedCalculator;
@@ -56,6 +57,7 @@ public class ExtraContextsPlugin extends JavaPlugin implements CommandExecutor {
         register("worldguard-region", "WorldGuard", WorldGuardRegionCalculator::new);
         register("worldguard-flag", "WorldGuard", WorldGuardFlagCalculator::new);
         register("whitelisted", null, WhitelistedCalculator::new);
+        register("is-op", null, OpCalculator::new);
         register("team", null, TeamCalculator::new);
         register("has-played-before", null, HasPlayedBeforeCalculator::new);
         register("placeholderapi", "PlaceholderAPI", () -> new PlaceholderApiCalculator(getConfig().getConfigurationSection("placeholderapi-placeholders")));

--- a/src/main/java/me/lucko/extracontexts/calculators/OpCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/OpCalculator.java
@@ -1,0 +1,25 @@
+package me.lucko.extracontexts.calculators;
+
+import net.luckperms.api.context.ContextCalculator;
+import net.luckperms.api.context.ContextConsumer;
+import net.luckperms.api.context.ContextSet;
+import net.luckperms.api.context.ImmutableContextSet;
+
+import org.bukkit.entity.Player;
+
+public class OpCalculator implements ContextCalculator<Player> {
+    private static final String KEY = "is-op";
+
+    @Override
+    public void calculate(Player target, ContextConsumer consumer) {
+        consumer.accept(KEY, String.valueOf(target.isOp()));
+    }
+
+    @Override
+    public ContextSet estimatePotentialContexts() {
+        return ImmutableContextSet.builder()
+                .add(KEY, "true")
+                .add(KEY, "false")
+                .build();
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -25,6 +25,12 @@ worldguard-flag: false
 # e.g. whitelisted=true
 whitelisted: false
 
+# Provides the 'is-op' context.
+# Returns if the player is a server operator or not.
+#
+# e.g. is-op=true
+is-op: false
+
 # Provides the 'team' context.
 # Returns the name of the team the players is in.
 #


### PR DESCRIPTION
Often people ask for "permissions only if they're op", might as well add it here.
