### PR TITLE
Fix NPE caused by null return

### DIFF
--- a/src/main/java/me/lucko/extracontexts/calculators/WorldGuardFlagCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/WorldGuardFlagCalculator.java
@@ -26,6 +26,9 @@ public class WorldGuardFlagCalculator implements ContextCalculator<Player> {
     @Override
     public void calculate(Player target, ContextConsumer consumer) {
         Map<IWrappedFlag<?>, Object> flags = this.worldGuard.queryApplicableFlags(target, target.getLocation());
+        if (flags == null) {
+            return;
+        }
         flags.forEach((flag, value) -> {
             if (invalidValue(value)) {
                 return;


### PR DESCRIPTION
This PR fixes the console spam of an NPE caused by WorldGuardWrapper returning null after encountering an unsupported region flag.

ex.
```
[06:19:39 WARN]: [LuckPerms] An exception was thrown by me.lucko.extracontexts.calculators.WorldGuardFlagCalculator whilst calculating the context of subject CraftPlayer{name=Sxtanna}
java.lang.NullPointerException: Cannot invoke "java.util.Map.forEach(java.util.function.BiConsumer)" because "flags" is null
        at me.lucko.extracontexts.calculators.WorldGuardFlagCalculator.calculate(WorldGuardFlagCalculator.java:29) ~[ExtraContexts.jar:?]
        at me.lucko.extracontexts.calculators.WorldGuardFlagCalculator.calculate(WorldGuardFlagCalculator.java:21) ~[ExtraContexts.jar:?]
```

This PR solves this problem by simply null checking the return value, a bandaid solution in case bumping the version of WGW is not desirable.