### PR TITLE
Fix NPE caused by null return / Bump WGW version to 1.2.0-SNAPSHOT, added CodeMC repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>org.codemc.worldguardwrapper</groupId>
             <artifactId>worldguardwrapper</artifactId>
-            <version>1.1.7</version>
+            <version>1.2.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
@@ -114,6 +114,10 @@
         <repository>
             <id>luck-repo</id>
             <url>https://repo.lucko.me/</url>
+        </repository>
+        <repository>
+            <id>codemc-repo</id>
+            <url>https://repo.codemc.org/repository/maven-public/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This PR fixes the console spam of an NPE caused by WorldGuardWrapper returning null after encountering an unsupported region flag.

ex.
```
[06:19:39 WARN]: [LuckPerms] An exception was thrown by me.lucko.extracontexts.calculators.WorldGuardFlagCalculator whilst calculating the context of subject CraftPlayer{name=Sxtanna}
java.lang.NullPointerException: Cannot invoke "java.util.Map.forEach(java.util.function.BiConsumer)" because "flags" is null
        at me.lucko.extracontexts.calculators.WorldGuardFlagCalculator.calculate(WorldGuardFlagCalculator.java:29) ~[ExtraContexts.jar:?]
        at me.lucko.extracontexts.calculators.WorldGuardFlagCalculator.calculate(WorldGuardFlagCalculator.java:21) ~[ExtraContexts.jar:?]
```
This PR solves this problem by bumping the version of WGW to latest, which includes a fix to this.

WGW
1.1.7 -> 1.2.0-SNAPSHOT