### PR TITLE
Fix IAE caused by effectively empty context value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>net.luckperms</groupId>
             <artifactId>api</artifactId>
-            <version>5.0</version>
+            <version>5.3</version>
             <scope>provided</scope>
         </dependency>
         <!-- Bukkit -->

--- a/src/main/java/me/lucko/extracontexts/calculators/WorldGuardFlagCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/WorldGuardFlagCalculator.java
@@ -1,5 +1,6 @@
 package me.lucko.extracontexts.calculators;
 
+import net.luckperms.api.context.Context;
 import net.luckperms.api.context.ContextCalculator;
 import net.luckperms.api.context.ContextConsumer;
 import net.luckperms.api.context.ContextSet;
@@ -62,7 +63,7 @@ public class WorldGuardFlagCalculator implements ContextCalculator<Player> {
     }
 
     private static boolean invalidValue(Object value) {
-        return value == null || value instanceof Location || value instanceof Vector;
+        return value == null || value instanceof Location || value instanceof Vector || (value instanceof String && !Context.isValidValue(((String) value)));
     }
 
 }


### PR DESCRIPTION
This PR fixes the console spam of an IAE caused by the luckperms api rejecting context values that are effectively empty.

ex.
```
[07:12:19] [Craft Scheduler Thread - 41 - FeatherBoard/WARN]: [LuckPerms] An exception was thrown by me.lucko.extracontexts.calculators.WorldGuardFlagCalculator whilst calculating the context of subject CraftPlayer{name=Sxtanna}
java.lang.IllegalArgumentException: value is (effectively) empty
	at me.lucko.luckperms.common.context.AbstractContextSet.sanitizeValue(AbstractContextSet.java:81) ~[?:?]
	at me.lucko.luckperms.common.context.ImmutableContextSetImpl$BuilderImpl.add(ImmutableContextSetImpl.java:281) ~[?:?]
```

The problem is solved by pre-checking the validity of the value using what luckperms uses.

Luckperms API
5.0 -> 5.3