### PR TITLE
Fix team context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>org.bukkit</groupId>
             <artifactId>bukkit</artifactId>
-            <version>1.12-R0.1-SNAPSHOT</version>
+            <version>1.12.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -107,6 +107,11 @@
             <artifactId>placeholderapi</artifactId>
             <version>2.9.2</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.18-R0.1-SNAPSHOT</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/me/lucko/extracontexts/calculators/TeamCalculator.java
+++ b/src/main/java/me/lucko/extracontexts/calculators/TeamCalculator.java
@@ -13,9 +13,15 @@ public class TeamCalculator implements ContextCalculator<Player> {
 
     @Override
     public void calculate(Player target, ContextConsumer consumer) {
-        Team team = Bukkit.getScoreboardManager().getMainScoreboard().getTeam(target.getName());
-        if (team != null) {
-            consumer.accept(KEY, team.getName());
+        String teamName = null;
+        for (Team team : Bukkit.getScoreboardManager().getMainScoreboard().getTeams()) {
+            if (team.hasEntry(target.getName())) {
+                teamName = team.getName();
+                break;
+            }
+        }
+        if (teamName != null) {
+            consumer.accept(KEY, teamName);
         }
     }
 


### PR DESCRIPTION
Fixes the team context not working properly. Currently it only works if the player name is the same as the team name because the `calculate` method checks for a team with the name of the player instead of the team that the player is in. This PR fixes that.

Fixes: https://github.com/LuckPerms/ExtraContexts/issues/44