### PR TITLE
Add spigotmc-repo to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,10 @@
 
     <repositories>
         <repository>
+            <id>spigotmc-repo</id>
+            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+        </repository>
+        <repository>
             <id>luck-repo</id>
             <url>https://repo.lucko.me/</url>
         </repository>


### PR DESCRIPTION
This change allows people to start building directly without having to deal with bukkit dependency.